### PR TITLE
Full control on the key option and uid added

### DIFF
--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -41,8 +41,9 @@ class Emitter {
     }
 
     $this->redis = $redis;
-    $this->key = (isset($opts['key']) ? $opts['key'] : 'socket.io') . '#emitter';
-
+    $this->key = (isset($opts['key']) ? $opts['key'] : 'socket.io#emitter');
+    $this->uid = (isset($opts['uid']) ? $opts['uid'] : 'emitter');
+    
     $this->_rooms = array();
     $this->_flags = array();
   }
@@ -117,7 +118,7 @@ class Emitter {
     }
 
     // publish
-    $packed = msgpack_pack(array($packet, array(
+    $packed = msgpack_pack(array($this->uid, $packet, array(
       'rooms' => $this->_rooms,
       'flags' => $this->_flags
     )));


### PR DESCRIPTION
Key option: needed for socket.io-redis compatibility, because currently socket.io-redis is using `prefix + '#' + namespace + '#'` and `prefix + '#' + namespace + '#' + room + '#'` formats of keys.

uid option added to make compatible with socket.io-emitter (1.0.0)
