### PR TITLE
socket.io-redis@0.2.0 compatibility fix: roomname format, msgpack format  

### DIFF
--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -122,7 +122,7 @@ class Emitter {
       'rooms' => $this->_rooms,
       'flags' => $this->_flags
     );
-	$chn = $this->prefix . '#' . $packet['nsp'] . '#';
+    $chn = $this->prefix . '#' . $packet['nsp'] . '#';
     $packed = msgpack_pack(array($this->uid,$packet,$opts));
 
     // hack buffer extensions for msgpack with binary
@@ -132,14 +132,14 @@ class Emitter {
     }
 
     // publish
-	if (is_array($this->_rooms) && count($this->_rooms) > 0) {
-		foreach ($this->_rooms as $room) {
-			$chnRoom = $chn . $room . '#';
-		    $this->redis->publish($chnRoom, $packed);
-		}
-	} else {
-	    $this->redis->publish($chn, $packed);
-	}
+    if (is_array($this->_rooms) && count($this->_rooms) > 0) {
+        foreach ($this->_rooms as $room) {
+            $chnRoom = $chn . $room . '#';
+            $this->redis->publish($chnRoom, $packed);
+        }
+    } else {
+        $this->redis->publish($chn, $packed);
+    }
 
     // reset state
     $this->_rooms = array();

--- a/test/test.php
+++ b/test/test.php
@@ -141,5 +141,50 @@ class EmitterTest extends PHPUnit_Framework_TestCase {
 
     $this->assertTrue(strpos($contents, '/nsp') !== FALSE);
   }
+
+  public function testPublishKeyNameWithNamespaceSet() {
+    $p = new Process('redis-cli monitor > redis.log');
+
+    sleep(1);
+    // Running this should produce something that's visible in `redis-cli monitor`
+    $emitter = new Emitter(NULL, array('host' => '127.0.0.1', 'port' => '6379'));
+    $emitter->of('/nsp')->emit('yolo', 'data');
+
+    $p->stop();
+    $contents= file_get_contents('redis.log');
+    unlink('redis.log');
+
+    $this->assertTrue(strpos($contents, 'socket.io#/nsp#') !== FALSE);
+  }
+
+  public function testPublishKeyNameWithRoomSet() {
+    $p = new Process('redis-cli monitor > redis.log');
+
+    sleep(1);
+    // Running this should produce something that's visible in `redis-cli monitor`
+    $emitter = new Emitter(NULL, array('host' => '127.0.0.1', 'port' => '6379'));
+    $emitter->to('rm')->emit('yolo', 'data');
+
+    $p->stop();
+    $contents= file_get_contents('redis.log');
+    unlink('redis.log');
+
+    $this->assertTrue(strpos($contents, 'socket.io#/#rm#') !== FALSE);
+  }
+
+  public function testPublishKeyNameWithNamespaceAndRoomSet() {
+    $p = new Process('redis-cli monitor > redis.log');
+
+    sleep(1);
+    // Running this should produce something that's visible in `redis-cli monitor`
+    $emitter = new Emitter(NULL, array('host' => '127.0.0.1', 'port' => '6379'));
+    $emitter->of('/nsp')->to('rm')->emit('yolo', 'data');
+
+    $p->stop();
+    $contents= file_get_contents('redis.log');
+    unlink('redis.log');
+
+    $this->assertTrue(strpos($contents, 'socket.io#/nsp#rm#') !== FALSE);
+  }
 }
 ?>


### PR DESCRIPTION
Fix for this issue:
https://github.com/rase-/socket.io-php-emitter/issues/20

This is a porting of this commit in the javascript implementation:
https://github.com/socketio/socket.io-emitter/commit/e656600388bdb3fc1cf62331e18d1a6a7775ab36

This fix is necessary to make `socket.io-php-emitter` work with `socket.io-redis` version > 0.2.0
